### PR TITLE
Fix ToC quickstart (usage) link

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@
 * Table of Contents                                                     :TOC:
  - [[#clj-http][clj-http]]
      - [[#installation][Installation]]
-     - [[#usage][Usage]]
+     - [[#quickstart][Quickstart]]
      - [[#input-coercion][Input coercion]]
      - [[#output-coercion][Output coercion]]
      - [[#misc][Misc]]


### PR DESCRIPTION
Looks like the Usage section changed to be Quickstart, but the ToC link was not updated.
